### PR TITLE
fix: send error message in plain telegram format

### DIFF
--- a/lido/steth/main.py
+++ b/lido/steth/main.py
@@ -55,11 +55,11 @@ def main():
             curve_rates = client.execute_batch(batch)
             if len(curve_rates) != len(amounts):
                 error_message = f"Batch response length mismatch. Expected: {len(amounts)}, Got: {len(curve_rates)}"
-                send_telegram_message(error_message, PROTOCOL)
+                send_telegram_message(error_message, PROTOCOL, True, True)
                 return
         except Exception as e:
             error_message = f"Error executing batch curve pool calls: {e}"
-            send_telegram_message(error_message, PROTOCOL)
+            send_telegram_message(error_message, PROTOCOL, True, True)
             return
 
         for amount, curve_rate in zip(amounts, curve_rates):
@@ -72,7 +72,7 @@ def main():
                     send_telegram_message(message, PROTOCOL)
             except Exception as e:
                 error_message = f"Error processing curve pool rate for amount {amount / 1e18:.2f}: {e}"
-                send_telegram_message(error_message, PROTOCOL)
+                send_telegram_message(error_message, PROTOCOL, True, True)
 
 
 if __name__ == "__main__":

--- a/morpho/markets.py
+++ b/morpho/markets.py
@@ -516,13 +516,13 @@ def main() -> None:
         response = requests.post(API_URL, json=json_data, timeout=30)
         response.raise_for_status()
     except requests.RequestException as e:
-        send_telegram_message(f"🚨 Problem with fetching data for Morpho markets: {str(e)} 🚨", PROTOCOL)
+        send_telegram_message(f"🚨 Problem with fetching data for Morpho markets: {str(e)} 🚨", PROTOCOL, True, True)
         return
 
     data = response.json()
     if "errors" in data:
         error_msg = data["errors"][0]["message"] if data["errors"] else "Unknown GraphQL error"
-        send_telegram_message(f"🚨 GraphQL error when fetching Morpho data: {error_msg} 🚨", PROTOCOL)
+        send_telegram_message(f"🚨 GraphQL error when fetching Morpho data: {error_msg} 🚨", PROTOCOL, True, True)
         return
 
     vaults_data = data.get("data", {}).get("vaults", {}).get("items", [])

--- a/morpho/markets_graph.py
+++ b/morpho/markets_graph.py
@@ -329,13 +329,13 @@ def check_graph_data_for_chain(chain: Chain):
         response = requests.post(api_url, json=json_data, timeout=30)
         response.raise_for_status()
     except requests.RequestException as e:
-        send_telegram_message(f"🚨 Problem with fetching data for Morpho markets: {str(e)} 🚨", PROTOCOL)
+        send_telegram_message(f"🚨 Problem with fetching data for Morpho markets: {str(e)} 🚨", PROTOCOL, True, True)
         return
 
     data = response.json()
     if "errors" in data:
         error_msg = data["errors"][0]["message"] if data["errors"] else "Unknown GraphQL error"
-        send_telegram_message(f"🚨 GraphQL error when fetching Morpho data: {error_msg} 🚨", PROTOCOL)
+        send_telegram_message(f"🚨 GraphQL error when fetching Morpho data: {error_msg} 🚨", PROTOCOL, True, True)
         return
 
     vaults_data = data.get("data", {}).get("metaMorphos", {})

--- a/resolv/resolv.py
+++ b/resolv/resolv.py
@@ -50,12 +50,12 @@ def main():
             else:
                 error_message = f"Batch Call: Expected 3 responses, got {len(responses)}"
                 print(error_message)
-                send_telegram_message(error_message, PROTOCOL)
+                send_telegram_message(error_message, PROTOCOL, True, True)
                 return  # Cannot proceed without expected data
 
     except Exception as e:
         error_message = f"Error during batch blockchain calls: {e}"
-        send_telegram_message(error_message, PROTOCOL)
+        send_telegram_message(error_message, PROTOCOL, True, True)
         return  # Cannot proceed if batch fails
 
     (usr_price, usr_supply, reserves, timestamp) = usr_last_price

--- a/rtoken/monitor_rtoken.py
+++ b/rtoken/monitor_rtoken.py
@@ -116,7 +116,7 @@ def monitor_rtoken_on_chain(chain: Chain):
         else:
             error_message = f"[{chain.network_name}] Batch Call: Expected 4 responses, got {len(responses)}"
             print(error_message)
-            send_telegram_message(error_message, PROTOCOL)
+            send_telegram_message(error_message, PROTOCOL, True, True)
             return
 
     # --- RToken Coverage Check ---
@@ -198,7 +198,7 @@ def main():
         except Exception as e:
             error_message = f"Critical error monitoring on {chain.network_name}. Check the logs."
             print(error_message + f"\n{e}")
-            send_telegram_message(error_message, PROTOCOL)
+            send_telegram_message(error_message, PROTOCOL, True, True)
 
 
 if __name__ == "__main__":

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -15,7 +15,9 @@ class TelegramError(Exception):
     pass
 
 
-def send_telegram_message(message: str, protocol: str, disable_notification: bool = False) -> None:
+def send_telegram_message(
+    message: str, protocol: str, disable_notification: bool = False, plain_text: bool = False
+) -> None:
     """
     Send a message to a Telegram chat using a bot.
 
@@ -48,7 +50,7 @@ def send_telegram_message(message: str, protocol: str, disable_notification: boo
     params = {
         "chat_id": chat_id,
         "text": message,
-        "parse_mode": "Markdown",
+        "parse_mode": "Markdown" if not plain_text else None,
         "disable_notification": disable_notification,
     }
 


### PR DESCRIPTION
This is a fix to telegram api exceptions, like this one: https://github.com/yearn/monitoring-scripts-py/actions/runs/16540115486/job/46780100987

We send messages in Markdown format, but when we try to send exception message from different libraries we get messages in invalid format.

Implementation uses plain text format when sending error message to telegram api.