### PR TITLE
feat: add caching for resolv

### DIFF
--- a/resolv/resolv.py
+++ b/resolv/resolv.py
@@ -73,7 +73,7 @@ def should_alert_redemption(current_usage: int, redemption_limit: int) -> bool:
 
     if still_above_threshold and time_since_reset >= twenty_four_hours:
         # Update reset time to prevent spam (alert once per 24h period)
-        print(f"Data over threshold for 24+ hours")
+        print("Data over threshold for 24+ hours")
         write_redemption_cache(current_usage, current_time)
         return True
 
@@ -154,6 +154,7 @@ def main() -> None:
             f"Current Redemption Usage is greater than 50% of Redemption Limit!\n"
             f"Current Redemption Usage: {current_redemption_usage / 1e18:.4f}\n"
             f"Redemption Limit: {redemption_limit / 1e18:.4f}\n"
+            f"Available redemption: {(redemption_limit - current_redemption_usage) / 1e18:.4f}"
         )
         error_messages.append(message)
 

--- a/resolv/resolv.py
+++ b/resolv/resolv.py
@@ -2,6 +2,7 @@ import time
 from datetime import datetime
 
 from utils.abi import load_abi
+from utils.cache import cache_filename, get_last_value_for_key_from_file, write_last_value_to_file
 from utils.chains import Chain
 from utils.telegram import send_telegram_message
 from utils.web3_wrapper import ChainManager
@@ -15,7 +16,75 @@ ABI_USR_PRICE_STORAGE = load_abi("resolv/abi/usr_price_storage.json")
 ABI_USR_REDEMPTION = load_abi("resolv/abi/usr_redemption.json")
 
 
-def main():
+def get_redemption_cache() -> tuple[int | None, int | None]:
+    """Returns (usage, last_reset_time) or (None, None) if no cache"""
+    cache_data = get_last_value_for_key_from_file(cache_filename, PROTOCOL)
+    if cache_data == 0:
+        return None, None
+
+    parts = str(cache_data).split("|")
+    if len(parts) == 2:
+        return int(parts[0]), int(parts[1])
+
+
+def write_redemption_cache(usage: int, reset_time: int) -> None:
+    """Write redemption cache data using existing cache system"""
+    cache_value = f"{usage}|{reset_time}"
+    write_last_value_to_file(cache_filename, PROTOCOL, cache_value)
+
+
+def should_alert_redemption(current_usage: int, redemption_limit: int) -> bool:
+    """
+    Smart caching logic that only writes to cache when necessary:
+    - On first run
+    - When reset is detected
+    - When threshold is crossed (alert triggered)
+    - When 24+ hours have passed since last reset and data is still over threshold
+    """
+    cached_usage, last_reset_time = get_redemption_cache()
+    current_time = int(time.time())
+    threshold = redemption_limit / 2
+
+    # First run - save cache and check threshold
+    if cached_usage is None:
+        write_redemption_cache(current_usage, current_time)
+        return current_usage > threshold
+
+    # Detect reset: current usage < cached usage indicates 24h reset happened
+    reset_detected = current_usage < cached_usage
+
+    if reset_detected:
+        # Reset detected - save new state and check threshold
+        write_redemption_cache(current_usage, current_time)
+        return current_usage > threshold
+
+    # Check if threshold crossed since last cache
+    threshold_crossed = (cached_usage <= threshold) and (current_usage > threshold)
+
+    if threshold_crossed:
+        # Threshold crossed - save cache and alert
+        write_redemption_cache(current_usage, last_reset_time)
+        return True
+
+    # Time-based alert: if above threshold and 24+ hours since last reset
+    time_since_reset = current_time - last_reset_time
+    still_above_threshold = current_usage > threshold
+    twenty_four_hours = 24 * 60 * 60
+
+    if still_above_threshold and time_since_reset >= twenty_four_hours:
+        # Update reset time to prevent spam (alert once per 24h period)
+        print(f"Data over threshold for 24+ hours")
+        write_redemption_cache(current_usage, current_time)
+        return True
+
+    # No significant change - don't save cache, just continue monitoring
+    print(
+        f"Cached usage: {cached_usage}, Last reset time: {last_reset_time}, Current usage: {current_usage}, Threshold: {threshold}"
+    )
+    return False
+
+
+def main() -> None:
     client = ChainManager.get_client(Chain.MAINNET)
 
     try:
@@ -80,7 +149,7 @@ def main():
         )
         error_messages.append(message)
 
-    if current_redemption_usage > redemption_limit / 2:
+    if should_alert_redemption(current_redemption_usage, redemption_limit):
         message = (
             f"Current Redemption Usage is greater than 50% of Redemption Limit!\n"
             f"Current Redemption Usage: {current_redemption_usage / 1e18:.4f}\n"

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -14,7 +14,7 @@ morpho_filename = os.getenv("MORPHO_FILENAME", "cache-id.txt")
 
 
 def get_last_queued_id_from_file(protocol):
-    return get_last_value_for_key_from_file(cache_filename, protocol)
+    return int(get_last_value_for_key_from_file(cache_filename, protocol))
 
 
 def write_last_queued_id_to_file(protocol, proposal_id):
@@ -22,7 +22,7 @@ def write_last_queued_id_to_file(protocol, proposal_id):
 
 
 def get_last_executed_nonce_from_file(safe_address):
-    return get_last_value_for_key_from_file(nonces_filename, safe_address)
+    return int(get_last_value_for_key_from_file(nonces_filename, safe_address))
 
 
 def write_last_executed_nonce_to_file(safe_address, nonce):
@@ -30,7 +30,7 @@ def write_last_executed_nonce_to_file(safe_address, nonce):
 
 
 def get_last_executed_morpho_from_file(vault_address, market_id, value_type):
-    return get_last_value_for_key_from_file(morpho_filename, morpho_key(vault_address, market_id, value_type))
+    return int(get_last_value_for_key_from_file(morpho_filename, morpho_key(vault_address, market_id, value_type)))
 
 
 def write_last_executed_morpho_to_file(vault_address, market_id, value_type, value):
@@ -51,7 +51,7 @@ def get_last_value_for_key_from_file(filename, wanted_key):
             for line in lines:
                 key, value = line.strip().split(":")
                 if key == wanted_key:
-                    return int(value)
+                    return value
     return 0
 
 


### PR DESCRIPTION
Add cache to skip alerting after the first message because redemption in RESOLV is rested after 24h. This way, we won't get multiple messages for the same redemption problem. 
If the redemption is exhausted after 24h, this means that it was reset, but it got exhausted again, so we need to send an alert again.