### PR TITLE
feat: changes in moonwell api data

### DIFF
--- a/moonwell/README.md
+++ b/moonwell/README.md
@@ -18,20 +18,12 @@ The script [proposals.py](proposals.py) to check for new governance proposals is
 
 ## Data Monitoring
 
-The script [bad_debt.py](bad_debt.py) is run hourly by Github actions. It fetches the data from [IntoTheBlock API](https://defirisk.intotheblock.com/metrics/base/moonwell) and [Gauntlet dashboard](https://dashboards.gauntlet.xyz/protocols/moonwell) and sends alerts if the thresholds are exceeded. If both data sources are not working, it sends an alert.
+The script [bad_debt.py](bad_debt.py) is run hourly by Github actions. It fetches the data from [Sentora API](https://defirisk.sentora.com/metrics/base/moonwell) and sends alerts if the thresholds are exceeded. If both data sources are not working, it sends an alert.
 
 ### Bad Debt
 
-The alerts are sent when the [bad debt ratio](bad_debt.py#L65) is greater than 0.5% or if the [debt supply ratio](bad_debt.py#L66) is greater than 70%. The data is fetched from [IntoTheBlock API](https://defirisk.intotheblock.com/metrics/base/moonwell).
-
-### Value at Risk
-
-The alerts are sent when the [value at risk](bad_debt.py#L50) is greater than 1% of the total debt. The data is fetched from [Gauntlet dashboard](https://dashboards.gauntlet.xyz/protocols/moonwell).
-
-### Liquidation at Risk
-
-The alerts are sent when the [liquidation at risk](bad_debt.py#L61) is greater than 5% of the total debt. The data is fetched from [Gauntlet dashboard](https://dashboards.gauntlet.xyz/protocols/moonwell).
+The alerts are sent when the [bad debt ratio](bad_debt.py#L65) is greater than 0.5% or if the [debt supply ratio](bad_debt.py#L66) is greater than 70%. The data is fetched from [Sentora API](https://defirisk.sentora.com/metrics/base/moonwell).
 
 ### Debt Supply Ratio
 
-The script fetches the data from [IntoTheBlock API](https://defirisk.intotheblock.com/metrics/base/moonwell) and [Gauntlet dashboard](https://dashboards.gauntlet.xyz/protocols/moonwell) and sends alerts if the debt supply ratio is greater than 70%.
+The script fetches the data from [Sentora API](https://defirisk.sentora.com/metrics/base/moonwell) and sends alerts if the debt supply ratio is greater than 70%.


### PR DESCRIPTION
- Gauntlet killed monitoring for moonwell because they switched to using anthias: https://risk.anthias.xyz/moonwell/base/overview
- IntoTheBlock is renamed to Sentora. We will use only this API to get the data.